### PR TITLE
Turn XAutoRepeat back on when exit via titlebar

### DIFF
--- a/main-x11.c
+++ b/main-x11.c
@@ -21,6 +21,7 @@
 ------------------------------------------------------------------*/
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/Xatom.h>
 #include <X11/keysym.h>
 #include <sys/types.h>
 
@@ -57,6 +58,7 @@ XTextProperty wname;
 char          *font_name = "10x20";
 unsigned int  window_width, window_height,
               display_width, display_height;
+Atom wmDeleteMessage;
 
 /*------------------------------------------------------------------
  * main
@@ -137,6 +139,10 @@ int Graphics_init ( unsigned int win_width, unsigned int win_height )
    black_gc = XCreateGC ( display, win, gc_valuemask, &gc_values );
    color_gc = XCreateGC ( display, win, gc_valuemask, &gc_values );
    text_gc  = XCreateGC ( display, win, gc_valuemask, &gc_values );
+
+   /* Get atom and indicate X11 client is willing to participate */
+   wmDeleteMessage = XInternAtom ( display, "WM_DELETE_WINDOW", False );
+   XSetWMProtocols ( display, win, &wmDeleteMessage, 1 );
 
    /* load default font */
    font_info = XLoadQueryFont ( display, font_name );
@@ -474,6 +480,15 @@ int Handle_events ( void )
 
                default:
                   break;
+            }
+            break;
+
+         case ClientMessage:
+            if ( event.xclient.data.l[0] >= 0 && ((unsigned long int) \
+                 event.xclient.data.l[0]) == wmDeleteMessage )
+            {
+               Graphics_shutdown ();
+               exit(0);
             }
             break;
 

--- a/player.c
+++ b/player.c
@@ -164,17 +164,17 @@ void Player_update1 ( OBJECT *obj )
    if ( (gv->key_LEFT1 == FALSE) && (gv->key_RIGHT1 == FALSE) && \
          player1->rot )
    {
-      if(player1->rot > 0) 
+      if ( player1->rot > 0 )
       {
          player1->rot -= ROT_Z * gv->fadjust;
-	 if(player1->rot < 0)
+         if ( player1->rot < 0 )
             player1->rot = 0;
-      } 
-      else 
+      }
+      else
       {
          player1->rot += ROT_Z * gv->fadjust;
-	 if(player1->rot > 0)
-	    player1->rot = 0;
+         if ( player1->rot > 0 )
+            player1->rot = 0;
       }
    }
 
@@ -235,17 +235,17 @@ void Player_update2 ( OBJECT *obj )
    if ( (gv->key_LEFT2 == FALSE) && (gv->key_RIGHT2 == FALSE) && \
          player2->rot )
    {
-      if(player2->rot > 0) 
+      if ( player2->rot > 0 )
       {
          player2->rot -= ROT_Z * gv->fadjust;
-	 if(player2->rot < 0)
+         if ( player2->rot < 0 )
             player2->rot = 0;
-      } 
-      else 
+      }
+      else
       {
          player2->rot += ROT_Z * gv->fadjust;
-	 if(player2->rot > 0)
-	    player2->rot = 0;
+         if ( player2->rot > 0 )
+            player2->rot = 0;
       }
    }
 


### PR DESCRIPTION
Prior to this patch, exiting the program via the titlebar would often result in keypresses no longer auto-repeating. This is more likely to happen in a native X11 environment than in Xwayland, especially if launching the program while holding down a button. Fixed the issue so this doesn't occur after the usual ways to close a program. Also, made prior patch follow style better.